### PR TITLE
refactoring

### DIFF
--- a/Minesweeper/Models/Commands/ActivateCellCommand.cs
+++ b/Minesweeper/Models/Commands/ActivateCellCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class ActivateCellCommand
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/CommandInvoker.cs
+++ b/Minesweeper/Models/Commands/CommandInvoker.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class CommandInvoker
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/IGameCommand.cs
+++ b/Minesweeper/Models/Commands/IGameCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class IGameCommand
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/SafeClickBonusCommand.cs
+++ b/Minesweeper/Models/Commands/SafeClickBonusCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class SafeClickBonusCommand
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/ShowBombBonusCommand.cs
+++ b/Minesweeper/Models/Commands/ShowBombBonusCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class ShowBombBonusCommand
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/ShowFreeCellBonusCommand.cs
+++ b/Minesweeper/Models/Commands/ShowFreeCellBonusCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class ShowFreeCellBonusCommand
+    {
+    }
+}

--- a/Minesweeper/Models/GameStateManager.cs
+++ b/Minesweeper/Models/GameStateManager.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models
+{
+    internal class GameStateManager
+    {
+    }
+}


### PR DESCRIPTION
Проблема: Порушення Single Responsibility Principle в GameManager
Опис проблеми:
Клас GameManager в файлі Minesweeper/Models/GameManager.cs має занадто багато відповідальностей і порушує принцип Single Responsibility. 
Він одночасно:
Управляє станом гри (ініціалізація, перевірка завершення)
Обробляє логіку активації клітинок
Управляє бонусами
Обчислює та управляє рахунком
Генерує поле через стратегії складності

Рішення:
Застосувати паттерн Command для обробки дій гравця та виділити окремий клас GameStateManager для управління станом гри. 
Це дозволить:
Розділити відповідальності між класами
Спростити тестування кожного компонента окремо
Додати можливість скасування дій (undo functionality)
Покращити читабельність коду

Новий файл: Minesweeper/Models/GameStateManager.cs
Цей клас буде відповідальний тільки за:
Відстеження стану гри (початок, кінець, перемога/поразка)
Перевірку умов завершення гри
Управління лічильниками (активні клітинки, бомби)

Змінений файл: Minesweeper/Models/GameManager.cs
Видалити методи, що стосуються безпосередньо обробки дій
Залишити тільки ініціалізацію та координацію між компонентами
Додати CommandInvoker для виконання команд

Змінений файл: Minesweeper/Models/ViewModels/MainViewModel.cs
Оновити виклики методів для використання нової архітектури команд
Адаптувати до нового GameStateManager