### PR TITLE
refactoring with code

### DIFF
--- a/Minesweeper/Models/Commands/ActivateCellCommand.cs
+++ b/Minesweeper/Models/Commands/ActivateCellCommand.cs
@@ -1,12 +1,126 @@
-﻿using System;
+﻿using Minesweeper.Models.Field;
+using Minesweeper.Models.DifficultyStrategy;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Minesweeper.Models.Commands
 {
-    internal class ActivateCellCommand
+    public class ActivateCellCommand : IGameCommand
     {
+        private readonly int _x;
+        private readonly int _y;
+        private readonly Field.Field _field;
+        private readonly GameStateManager _gameState;
+        private readonly IDifficultyStrategy _difficultyStrategy;
+        private readonly int _rows;
+        private readonly int _columns;
+
+        private readonly List<(int x, int y)> _activatedCells = new List<(int x, int y)>();
+
+        public ActivateCellCommand(int x, int y, Field.Field field, GameStateManager gameState,
+            IDifficultyStrategy difficultyStrategy, int rows, int columns)
+        {
+            _x = x;
+            _y = y;
+            _field = field;
+            _gameState = gameState;
+            _difficultyStrategy = difficultyStrategy;
+            _rows = rows;
+            _columns = columns;
+        }
+
+        public bool CanExecute()
+        {
+            return IsWithinBounds(_x, _y) && !_gameState.IsEnd && !_field.Cells[_x, _y].IsActivated;
+        }
+
+        public void Execute()
+        {
+            if (!CanExecute()) return;
+
+            // Якщо це перший хід і клітинка не пуста, перегенеруємо поле
+            if (_gameState.IsFirstMove(_field, _rows, _columns) && _field.Cells[_x, _y].CellType != CellType.None)
+            {
+                RegenerateFieldUntilCellIsEmpty();
+            }
+
+            ActivateCell(_x, _y);
+            _gameState.CheckWinCondition(_field);
+        }
+
+        public void Undo()
+        {
+            // Скасування активації клітинок (для майбутнього розширення)
+            foreach (var (x, y) in _activatedCells)
+            {
+                _field.Cells[x, y].IsActivated = false;
+                _field.ActiveCellsRemain++;
+            }
+            _activatedCells.Clear();
+        }
+
+        private void ActivateCell(int x, int y)
+        {
+            if (!IsWithinBounds(x, y) || _field.Cells[x, y].IsActivated)
+                return;
+
+            Cell cell = _field.Cells[x, y];
+            cell.Activate();
+            _activatedCells.Add((x, y));
+
+            if (cell.IsBomb)
+            {
+                HandleBombActivation();
+            }
+            else
+            {
+                _difficultyStrategy.UpdateScore(cell.CellType);
+                _field.ActiveCellsRemain--;
+
+                if (cell.CellType == CellType.None)
+                {
+                    ActivateAdjacentCells(x, y);
+                }
+            }
+
+            _gameState.IsSafeClick = false;
+        }
+
+        private void HandleBombActivation()
+        {
+            if (_gameState.IsSafeClick)
+            {
+                _field.BombCount--;
+            }
+            else
+            {
+                _gameState.EndGame(false);
+            }
+        }
+
+        private void ActivateAdjacentCells(int x, int y)
+        {
+            for (int i = -1; i <= 1; i++)
+            {
+                for (int j = -1; j <= 1; j++)
+                {
+                    if ((i != 0 || j != 0) && IsWithinBounds(x + i, y + j))
+                    {
+                        ActivateCell(x + i, y + j);
+                    }
+                }
+            }
+        }
+
+        private void RegenerateFieldUntilCellIsEmpty()
+        {
+            while (_field.Cells[_x, _y].CellType != CellType.None)
+            {
+                _difficultyStrategy.GenerateField();
+            }
+        }
+
+        private bool IsWithinBounds(int x, int y) =>
+            x >= 0 && y >= 0 && x < _rows && y < _columns;
     }
 }

--- a/Minesweeper/Models/Commands/ActivateCellCommand.cs
+++ b/Minesweeper/Models/Commands/ActivateCellCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class ActivateCellCommand
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/CommandInvoker.cs
+++ b/Minesweeper/Models/Commands/CommandInvoker.cs
@@ -6,7 +6,31 @@ using System.Threading.Tasks;
 
 namespace Minesweeper.Models.Commands
 {
-    internal class CommandInvoker
+    public class CommandInvoker
     {
+        private readonly Stack<IGameCommand> _commandHistory = new Stack<IGameCommand>();
+
+        public void ExecuteCommand(IGameCommand command)
+        {
+            if (command.CanExecute())
+            {
+                command.Execute();
+                _commandHistory.Push(command);
+            }
+        }
+
+        public void UndoLastCommand()
+        {
+            if (_commandHistory.Count > 0)
+            {
+                var lastCommand = _commandHistory.Pop();
+                lastCommand.Undo();
+            }
+        }
+
+        public void ClearHistory()
+        {
+            _commandHistory.Clear();
+        }
     }
 }

--- a/Minesweeper/Models/Commands/CommandInvoker.cs
+++ b/Minesweeper/Models/Commands/CommandInvoker.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class CommandInvoker
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/IGameCommand.cs
+++ b/Minesweeper/Models/Commands/IGameCommand.cs
@@ -6,7 +6,10 @@ using System.Threading.Tasks;
 
 namespace Minesweeper.Models.Commands
 {
-    internal class IGameCommand
+    public interface IGameCommand
     {
+        void Execute();
+        bool CanExecute();
+        void Undo();
     }
 }

--- a/Minesweeper/Models/Commands/IGameCommand.cs
+++ b/Minesweeper/Models/Commands/IGameCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class IGameCommand
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/SafeClickBonusCommand.cs
+++ b/Minesweeper/Models/Commands/SafeClickBonusCommand.cs
@@ -1,12 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Minesweeper.Models.Commands
+﻿namespace Minesweeper.Models.Commands
 {
-    internal class SafeClickBonusCommand
+    public class SafeClickBonusCommand : IGameCommand
     {
+        private readonly GameManager _gameManager;
+        private readonly GameStateManager _gameState;
+
+        public SafeClickBonusCommand(GameManager gameManager, GameStateManager gameState)
+        {
+            _gameManager = gameManager;
+            _gameState = gameState;
+        }
+
+        public bool CanExecute()
+        {
+            return _gameManager.SafeClickBonusQuantity > 0 && !_gameState.IsEnd;
+        }
+
+        public void Execute()
+        {
+            if (!CanExecute()) return;
+
+            _gameState.IsSafeClick = true;
+            _gameManager.SafeClickBonusQuantity--;
+        }
+
+        public void Undo()
+        {
+            _gameState.IsSafeClick = false;
+            _gameManager.SafeClickBonusQuantity++;
+        }
     }
 }

--- a/Minesweeper/Models/Commands/SafeClickBonusCommand.cs
+++ b/Minesweeper/Models/Commands/SafeClickBonusCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class SafeClickBonusCommand
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/ShowBombBonusCommand.cs
+++ b/Minesweeper/Models/Commands/ShowBombBonusCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class ShowBombBonusCommand
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/ShowBombBonusCommand.cs
+++ b/Minesweeper/Models/Commands/ShowBombBonusCommand.cs
@@ -1,12 +1,38 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Minesweeper.Models.Commands
 {
-    internal class ShowBombBonusCommand
+    public class ShowBombBonusCommand : IGameCommand
     {
+        private const int BombBonusPenalty = 1000;
+
+        private readonly GameManager _gameManager;
+        private readonly GameStateManager _gameState;
+
+        public ShowBombBonusCommand(GameManager gameManager, GameStateManager gameState)
+        {
+            _gameManager = gameManager;
+            _gameState = gameState;
+        }
+
+        public bool CanExecute()
+        {
+            return _gameManager.ShowBombBonusQuantity > 0 && !_gameState.IsEnd;
+        }
+
+        public void Execute()
+        {
+            if (!CanExecute()) return;
+
+            _gameState.AddToScore(-BombBonusPenalty);
+            _gameManager.ShowBombBonusQuantity--;
+
+        }
+
+        public void Undo()
+        {
+            _gameState.AddToScore(BombBonusPenalty);
+            _gameManager.ShowBombBonusQuantity++;
+        }
     }
 }

--- a/Minesweeper/Models/Commands/ShowFreeCellBonusCommand.cs
+++ b/Minesweeper/Models/Commands/ShowFreeCellBonusCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models.Commands
+{
+    internal class ShowFreeCellBonusCommand
+    {
+    }
+}

--- a/Minesweeper/Models/Commands/ShowFreeCellBonusCommand.cs
+++ b/Minesweeper/Models/Commands/ShowFreeCellBonusCommand.cs
@@ -1,12 +1,72 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Minesweeper.Models.Field;
+using System;
 
 namespace Minesweeper.Models.Commands
 {
-    internal class ShowFreeCellBonusCommand
+    public class ShowFreeCellBonusCommand : IGameCommand
     {
+        private const int FreeCellBonusPenalty = 500;
+
+        private readonly GameManager _gameManager;
+        private readonly GameStateManager _gameState;
+        private readonly CommandInvoker _commandInvoker;
+
+        private (int x, int y) _activatedCell = (-1, -1);
+
+        public ShowFreeCellBonusCommand(GameManager gameManager, GameStateManager gameState, CommandInvoker commandInvoker)
+        {
+            _gameManager = gameManager;
+            _gameState = gameState;
+            _commandInvoker = commandInvoker;
+        }
+
+        public bool CanExecute()
+        {
+            return _gameManager.ShowFreeCellBonusQuantity > 0 && !_gameState.IsEnd;
+        }
+
+        public void Execute()
+        {
+            if (!CanExecute()) return;
+
+            _gameState.AddToScore(-FreeCellBonusPenalty);
+            _gameManager.ShowFreeCellBonusQuantity--;
+
+            if (!TryActivateFirstCell(c => c.CellType == CellType.None))
+            {
+                TryActivateFirstCell(c => c.CellType != CellType.Bomb);
+            }
+        }
+
+        public void Undo()
+        {
+            if (_activatedCell.x >= 0)
+            {
+                _gameState.AddToScore(FreeCellBonusPenalty);
+                _gameManager.ShowFreeCellBonusQuantity++;
+
+                _activatedCell = (-1, -1);
+            }
+        }
+
+        private bool TryActivateFirstCell(Func<Cell, bool> cellSelector)
+        {
+            for (int i = 0; i < _gameManager.Rows; i++)
+            {
+                for (int j = 0; j < _gameManager.Columns; j++)
+                {
+                    var cell = _gameManager.Field.Cells[i, j];
+                    if (!cell.IsActivated && cellSelector(cell))
+                    {
+                        var activateCommand = new ActivateCellCommand(i, j, _gameManager.Field, _gameState,
+                            _gameManager.DifficultyStrategy, _gameManager.Rows, _gameManager.Columns);
+                        _commandInvoker.ExecuteCommand(activateCommand);
+                        _activatedCell = (i, j);
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
     }
 }

--- a/Minesweeper/Models/DifficultyStrategy/BeginnerDifficultyStrategy.cs
+++ b/Minesweeper/Models/DifficultyStrategy/BeginnerDifficultyStrategy.cs
@@ -38,7 +38,7 @@ namespace Minesweeper.Models.DifficultyStrategy
         public override void UpdateScore(CellType cellType)
         {
             int score = ScoreMap.TryGetValue(cellType, out int value) ? value : 100;
-            GameManager.Score += score;
+            GameManager.GameState.AddToScore(score);
         }
 
         public override void SetBonusesQuantity()

--- a/Minesweeper/Models/DifficultyStrategy/ExpertDifficultyStrategy.cs
+++ b/Minesweeper/Models/DifficultyStrategy/ExpertDifficultyStrategy.cs
@@ -31,7 +31,7 @@ namespace Minesweeper.Models.DifficultyStrategy
         {
             // Експертний рівень: більш складна формула
             int score = (int)cellType * 100 + 100;
-            GameManager.Score += score;
+            GameManager.GameState.AddToScore(score);
         }
 
         public override void SetBonusesQuantity()

--- a/Minesweeper/Models/DifficultyStrategy/IntermediateDifficultyStrategy.cs
+++ b/Minesweeper/Models/DifficultyStrategy/IntermediateDifficultyStrategy.cs
@@ -43,7 +43,7 @@ namespace Minesweeper.Models.DifficultyStrategy
         public override void UpdateScore(CellType cellType)
         {
             int score = ScoreMap.TryGetValue(cellType, out int value) ? value : 300;
-            GameManager.Score += score;
+            GameManager.GameState.AddToScore(score);
         }
 
         public override void SetBonusesQuantity()

--- a/Minesweeper/Models/GameStateManager.cs
+++ b/Minesweeper/Models/GameStateManager.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minesweeper.Models
+{
+    internal class GameStateManager
+    {
+    }
+}

--- a/Minesweeper/Models/GameStateManager.cs
+++ b/Minesweeper/Models/GameStateManager.cs
@@ -1,12 +1,55 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Minesweeper.Models.Field;
+using System;
 
 namespace Minesweeper.Models
 {
-    internal class GameStateManager
+    public class GameStateManager
     {
+        public bool IsEnd { get; private set; }
+        public bool IsWin { get; private set; }
+        public bool IsSafeClick { get; set; }
+        public int Score { get; private set; }
+
+        public event Action<bool> GameEnded;
+        public event Action<int> ScoreChanged;
+
+        public void Initialize()
+        {
+            IsEnd = false;
+            IsWin = false;
+            IsSafeClick = false;
+            Score = 0;
+        }
+
+        public void AddToScore(int points)
+        {
+            Score += points;
+            if (Score < 0)
+                Score = 0;
+
+            ScoreChanged?.Invoke(Score);
+        }
+
+        public void CheckWinCondition(Field.Field field)
+        {
+            if (field.ActiveCellsRemain == 0 && !IsEnd)
+            {
+                EndGame(true);
+            }
+        }
+
+        public void EndGame(bool isWin)
+        {
+            if (IsEnd) return; // Запобігаємо подвійному завершенню
+
+            IsEnd = true;
+            IsWin = isWin;
+            GameEnded?.Invoke(isWin);
+        }
+
+        public bool IsFirstMove(Field.Field field, int rows, int columns)
+        {
+            return field.ActiveCellsRemain == rows * columns - field.BombCount;
+        }
     }
 }

--- a/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs
+++ b/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs
@@ -104,7 +104,7 @@ namespace Minesweeper.Models.ViewModels.Commands
 
             var canExecute = (object o) =>
             {
-                return vm.GameManager.ShowFreeCellBonusQuantity > 0;
+                return vm.GameManager.ShowFreeCellBonusQuantity > 0 && !vm.GameManager.IsEnd;
             };
 
             return new RelayCommand(execute, canExecute);

--- a/Minesweeper/Models/ViewModels/MainViewModel.cs
+++ b/Minesweeper/Models/ViewModels/MainViewModel.cs
@@ -21,8 +21,20 @@ namespace Minesweeper.Models.ViewModels
             Menu = new MenuViewModel(repository, this);
 
             GameManager = new GameManager();
-
+            GameManager.GameState.GameEnded += OnGameEnded;
+            GameManager.GameState.ScoreChanged += OnScoreChanged;
             InitializeCommands();
+        }
+
+
+        private void OnGameEnded(bool isWin)
+        {
+            EndGame();
+        }
+
+        private void OnScoreChanged(int newScore)
+        {
+            GameStatus?.Update();
         }
 
         public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
Проблема: Порушення Single Responsibility Principle в GameManager
Опис проблеми:
Клас GameManager в файлі Minesweeper/Models/GameManager.cs має занадто багато відповідальностей і порушує принцип Single Responsibility.
Він одночасно:
Управляє станом гри (ініціалізація, перевірка завершення)
Обробляє логіку активації клітинок
Управляє бонусами
Обчислює та управляє рахунком
Генерує поле через стратегії складності

Рішення:
Застосувати паттерн Command для обробки дій гравця та виділити окремий клас GameStateManager для управління станом гри.
Це дозволить:
Розділити відповідальності між класами
Спростити тестування кожного компонента окремо
Додати можливість скасування дій (undo functionality)
Покращити читабельність коду

Новий файл: Minesweeper/Models/GameStateManager.cs
Цей клас буде відповідальний тільки за:
Відстеження стану гри (початок, кінець, перемога/поразка)
Перевірку умов завершення гри
Управління лічильниками (активні клітинки, бомби)

Змінений файл: Minesweeper/Models/GameManager.cs
Видалити методи, що стосуються безпосередньо обробки дій
Залишити тільки ініціалізацію та координацію між компонентами
Додати CommandInvoker для виконання команд

Змінений файл: Minesweeper/Models/ViewModels/MainViewModel.cs
Оновити виклики методів для використання нової архітектури команд
Адаптувати до нового GameStateManager