### PR TITLE
[REFACTOR] Implemented Extract Method to GameCommadService

### DIFF
--- a/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs
+++ b/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs
@@ -11,319 +11,214 @@ using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Minesweeper.Models.ViewModels.Commands
 {
-    public static class GameCommandService
-    {
-        public class CellActionService
-        {
-            private readonly MainViewModel _vm;
+	public static class GameCommandService
+	{
+		public class CellActionService
+		{
+			private readonly MainViewModel _vm;
 
-            public CellActionService(MainViewModel vm)
-            {
-                _vm = vm;
-            }
+			public CellActionService(MainViewModel vm)
+			{
+				_vm = vm;
+			}
 
-            public void CheckBombAt(int index)
-            {
-                var cell = _vm.Cells[index];
-                _vm.GameManager.ActivateCell(cell.X, cell.Y);
-                cell.Clicked = true;
+			public void CheckBombAt(int index)
+			{
+				var cell = _vm.Cells[index];
+				_vm.GameManager.ActivateCell(cell.X, cell.Y);
+				cell.Clicked = true;
 
-                if (_vm.GameManager.Field.Cells[cell.X, cell.Y].CellType == Field.CellType.None)
-                {
-                    _vm.UpdateGameStatus(true);
-                }
-                else
-                {
-                    _vm.UpdateImageByType(cell);
-                    _vm.UpdateGameStatus(false);
+				if (_vm.GameManager.Field.Cells[cell.X, cell.Y].CellType == Field.CellType.None)
+				{
+					_vm.UpdateGameStatus(true);
+				}
+				else
+				{
+					_vm.UpdateImageByType(cell);
+					_vm.UpdateGameStatus(false);
 
-                    if (cell.Flaged)
-                    {
-                        cell.Flaged = false;
-                        _vm.GameStatus.BombCellCount++;
-                    }
-                }
-            }
+					if (cell.Flaged)
+					{
+						cell.Flaged = false;
+						_vm.GameStatus.BombCellCount++;
+					}
+				}
+			}
 
-            public void ToggleFlagAt(int index)
-            {
-                var cell = _vm.Cells[index];
+			public void ToggleFlagAt(int index)
+			{
+				var cell = _vm.Cells[index];
 
-                if (!cell.Clicked)
-                {
-                    if (cell.Flaged)
-                    {
-                        _vm.UpdateImage(cell, "block");
-                        _vm.GameStatus.BombCellCount++;
-                    }
-                    else
-                    {
-                        _vm.UpdateImage(cell, "flag");
-                        _vm.GameStatus.BombCellCount--;
-                    }
+				if (!cell.Clicked)
+				{
+					if (cell.Flaged)
+						UnflagCell(cell);
+					else
+						FlagCell(cell);
 
-                    cell.Flaged = !cell.Flaged;
-                }
-            }
+					cell.Flaged = !cell.Flaged;
+				}
+			}
 
-            public bool CanCheck(int index) =>
-                !_vm.Cells[index].Clicked && !_vm.GameStatus.IsGameEnded;
+			private void UnflagCell(CellViewModel cell)
+			{
+				cell.Flaged = false;
+				_vm.GameStatus.BombCellCount++;
+				_vm.UpdateImage(cell, "block");
+			}
 
-            public bool CanToggleFlag(int index) =>
-                (_vm.GameStatus.BombCellCount > 0 || _vm.Cells[index].Flaged) && !_vm.GameStatus.IsGameEnded;
-        }
+			private void FlagCell(CellViewModel cell)
+			{
+				cell.Flaged = true;
+				_vm.GameStatus.BombCellCount--;
+				_vm.UpdateImage(cell, "flag");
+			}
 
-        public static RelayCommand CreateCheckBombCommand(MainViewModel vm)
-        {
-            var service = new CellActionService(vm);
+			public bool CanCheck(int index) =>
+				!_vm.Cells[index].Clicked && !_vm.GameStatus.IsGameEnded;
 
-            return new RelayCommand(
-                execute: o => service.CheckBombAt((int)o),
-                canExecute: o => service.CanCheck((int)o)
-            );
-        }
+			public bool CanToggleFlag(int index) =>
+				(_vm.GameStatus.BombCellCount > 0 || _vm.Cells[index].Flaged) && !_vm.GameStatus.IsGameEnded;
+		}
 
-        public static RelayCommand CreateFlagCommand(MainViewModel vm)
-        {
-            var service = new CellActionService(vm);
+		public static RelayCommand CreateCheckBombCommand(MainViewModel vm)
+		{
+			var service = new CellActionService(vm);
+			return CreateCommand(o => service.CheckBombAt((int)o), o => service.CanCheck((int)o));
+		}
 
-            return new RelayCommand(
-                execute: o => service.ToggleFlagAt((int)o),
-                canExecute: o => service.CanToggleFlag((int)o)
-            );
-        }
+		public static RelayCommand CreateFlagCommand(MainViewModel vm)
+		{
+			var service = new CellActionService(vm);
+			return CreateCommand(o => service.ToggleFlagAt((int)o), o => service.CanToggleFlag((int)o));
+		}
 
+		public static RelayCommand CreateShowFreeCellCommand(MainViewModel vm) =>
+			BonusCommand(() => vm.GameManager.ShowFreeCellBonusQuantity > 0 && !vm.GameManager.IsEnd,
+						 () => { vm.GameManager.ShowFreeCellBonus(); vm.UpdateGameStatus(true); });
 
-        public static RelayCommand CreateShowFreeCellCommand(MainViewModel vm)
-        {
-            var execute = (object o) =>
-            {
-                vm.GameManager.ShowFreeCellBonus();
-                vm.UpdateGameStatus(true);
-            };
+		public static RelayCommand CreateShowBombCommand(MainViewModel vm)
+		{
+			return BonusCommand(
+				() => vm.GameStatus?.BombCellCount > 0 && vm.GameManager?.ShowBombBonusQuantity > 0 && vm.Cells.Any(x => x.Clicked),
+				() =>
+				{
+					vm.GameManager.ShowBombBonus();
+					foreach (var cell in vm.Cells)
+					{
+						if (!cell.Flaged && vm.GameManager.Field.Cells[cell.X, cell.Y].IsBomb)
+						{
+							cell.Flaged = true;
+							vm.UpdateImage(cell, "flag");
+							vm.GameStatus.BombCellCount--;
+							break;
+						}
+					}
+				});
+		}
 
-            var canExecute = (object o) =>
-            {
-                return vm.GameManager.ShowFreeCellBonusQuantity > 0 && !vm.GameManager.IsEnd;
-            };
+		public static RelayCommand CreateSafeClickCommand(MainViewModel vm) =>
+			BonusCommand(() => vm.GameManager.SafeClickBonusQuantity > 0,
+						 () => vm.GameManager.SafeClickBonus());
 
-            return new RelayCommand(execute, canExecute);
-        }
+		public static RelayCommand CreateInitializeGameCommand(MainViewModel vm) =>
+			CreateCommand(o => vm.InitializeGame(vm.Rows, vm.Columns, vm.Difficulty));
 
-        public static RelayCommand CreateShowBombCommand(MainViewModel vm)
-        {
-            var execute = (object o) =>
-            {
-                vm.GameManager.ShowBombBonus();
+		public static RelayCommand CreateBackToMenuCommand(MainViewModel vm) =>
+			CreateCommand(o => vm.Menu.InitializeProp(false), o => !vm.Menu.IsMenu);
 
-                foreach (var cell in vm.Cells)
-                {
-                    if (!cell.Flaged && vm.GameManager.Field.Cells[cell.X, cell.Y].IsBomb)
-                    {
-                        cell.Flaged = true;
-                        vm.UpdateImage(cell, "flag");
-                        vm.GameStatus.BombCellCount--;
-                        break;
-                    }
-                }
-            };
+		public static RelayCommand CreateRegisterCommand(MenuViewModel vm, IGameRepository repository) =>
+			CreateCommand(o => HandleAuth(vm, repository.RegisterUser, "Користувач з таким логіном вже існує!"));
 
-            var canExecute = (object o) =>
-            {
-                return vm.GameStatus?.BombCellCount > 0 && vm.GameManager?.ShowBombBonusQuantity > 0 && vm.Cells.Where(x => x.Clicked).Any();
-            };
+		public static RelayCommand CreateLoginCommand(MenuViewModel vm, IGameRepository repository) =>
+			CreateCommand(o => HandleAuth(vm, repository.LoginUser, "Неправильний логін та/або пароль!"));
 
-            return new RelayCommand(execute, canExecute);
-        }
+		public static RelayCommand CreateChangeLoginAndRegisterCommand(MenuViewModel vm) =>
+			CreateCommand(o =>
+			{
+				vm.Login = "";
+				vm.Password = "";
+				vm.Error = "";
+				vm.IsLogin = !vm.IsLogin;
+			});
 
-        public static RelayCommand CreateSafeClickCommand(MainViewModel vm)
-        {
-            var execute = (object o) =>
-            {
-                vm.GameManager.SafeClickBonus();
-            };
+		public static RelayCommand CreateChooseDifficultyCommand(MenuViewModel vm) =>
+			CreateCommand(o =>
+			{
+				vm.Rows = "";
+				vm.Columns = "";
+				vm.IsChoosingDifficulty = !vm.IsChoosingDifficulty;
+			});
 
-            var canExecute = (object o) =>
-            {
-                return vm.GameManager.SafeClickBonusQuantity > 0;
-            };
+		public static RelayCommand CreateStartCommand(MenuViewModel vm, MainViewModel mainVm) =>
+			CreateCommand(o =>
+			{
+				if (vm.Rows == "" || vm.Columns == "")
+				{
+					vm.Error = "Заповніть всі поля!";
+				}
+				else if (int.TryParse(vm.Rows, out int rows) && int.TryParse(vm.Columns, out int columns))
+				{
+					if (rows < 5 || columns < 5 || rows > 40 || columns > 40)
+					{
+						vm.Error = "Введіть коректні значення: від 5 до 40";
+					}
+					else
+					{
+						string difficulty = (string)o;
+						vm.IsChoosingDifficulty = false;
+						vm.IsMenu = false;
+						mainVm.InitializeGame(rows, columns, difficulty);
+					}
+				}
+				else
+				{
+					vm.Error = "Введіть коректні числові значення!";
+				}
+			});
 
-            return new RelayCommand(execute, canExecute);
-        }
+		public static RelayCommand CreateHistoryCommand(MenuViewModel vm, IGameRepository repository) =>
+			CreateCommand(o =>
+			{
+				if ((string)o == "True")
+				{
+					vm.GameResults = repository.GetResults(vm.UserId);
+				}
+				vm.IsHistory = !vm.IsHistory;
+			});
 
-        public static RelayCommand CreateInitializeGameCommand(MainViewModel vm)
-        {
-            var execute = (object o) =>
-            {
-                vm.InitializeGame(vm.Rows, vm.Columns, vm.Difficulty);
-            };
+		public static RelayCommand CreateExitAccountCommand(MenuViewModel vm) =>
+			CreateCommand(o => vm.InitializeProp(true));
 
-            return new RelayCommand(execute);
-        }
-
-        public static RelayCommand CreateBackToMenuCommand(MainViewModel vm)
-        {
-            var execute = (object o) =>
-            {
-                vm.Menu.InitializeProp(false);
-            };
-
-            var canExecute = (object o) =>
-            {
-                return !vm.Menu.IsMenu;
-            };
-
-            return new RelayCommand(execute, canExecute);
-        }
-
-        private static bool IsLoginAndPasswordValid(MenuViewModel vm)
-        {
-            return !string.IsNullOrWhiteSpace(vm.Login) && !string.IsNullOrWhiteSpace(vm.Password);
-        }
-
-        public static RelayCommand CreateRegisterCommand(MenuViewModel vm, IGameRepository repository)
-        {
-            var execute = (object o) =>
-            {
-                if (IsLoginAndPasswordValid(vm))
-                {
-                    int result = repository.RegisterUser(vm.Login, vm.Password);
-
-                    if (result > 0)
-                    {
-                        vm.UserId = result;
-                        vm.IsLoginScreen = false;
-                    }
-                    else
-                    {
-                        vm.Error = "Користувач з таким логіном вже існує!";
-                    }
-                }
-                else
-                {
-                    vm.Error = "Заповніть всі поля!";
-                }
-            };
-
-            return new RelayCommand(execute);
-        }
+		public static RelayCommand CreateExitCommand(MenuViewModel vm) =>
+			CreateCommand(o => vm.InvokeExitRequest());
 
 
-        public static RelayCommand CreateLoginCommand(MenuViewModel vm, IGameRepository repository)
-        {
-            var execute = (object o) =>
-            {
-                if (IsLoginAndPasswordValid(vm))
-                {
-                    int result = repository.LoginUser(vm.Login, vm.Password);
+		private static RelayCommand CreateCommand(Action<object> execute, Func<object, bool>? canExecute = null) =>
+			new RelayCommand(execute, canExecute);
 
-                    if (result > 0)
-                    {
-                        vm.UserId = result;
-                        vm.IsLoginScreen = false;
-                    }
-                    else
-                    {
-                        vm.Error = "Неправильний логін та/або пароль!";
-                    }
-                }
-                else
-                {
-                    vm.Error = "Заповніть всі поля!";
-                }
-            };
+		private static RelayCommand BonusCommand(Func<bool> canExecute, Action execute) =>
+			new RelayCommand(o => execute(), o => canExecute());
 
-            return new RelayCommand(execute);
-        }
-
-        public static RelayCommand CreateChangeLoginAndRegisterCommand(MenuViewModel vm)
-        {
-            var execute = (object o) =>
-            {
-                vm.Login = "";
-                vm.Password = "";
-                vm.Error = "";
-                vm.IsLogin = !vm.IsLogin;
-            };
-
-            return new RelayCommand(execute);
-        }
-
-        public static RelayCommand CreateChooseDifficultyCommand(MenuViewModel vm)
-        {
-            var execute = (object o) =>
-            {
-                vm.Rows = "";
-                vm.Columns = "";
-                vm.IsChoosingDifficulty = !vm.IsChoosingDifficulty;
-            };
-
-            return new RelayCommand(execute);
-        }
-
-        public static RelayCommand CreateStartCommand(MenuViewModel vm, MainViewModel mainVm)
-        {
-            var execute = (object o) =>
-            {
-                if (vm.Rows == "" || vm.Columns == "")
-                {
-                    vm.Error = "Заповніть всі поля!";
-                }
-                else
-                {
-                    int.TryParse(vm.Rows, out int rows);
-                    int.TryParse(vm.Columns, out int columns);
-
-                    if (rows < 5 || columns < 5 || rows > 40 || columns > 40)
-                    {
-                        vm.Error = "Введіть коректні значення: від 5 до 40";
-                    }
-                    else
-                    {
-                        string difficulty = (string)o;
-                        vm.IsChoosingDifficulty = false;
-                        vm.IsMenu = false;
-
-                        mainVm.InitializeGame(rows, columns, difficulty);
-                    }
-                }
-            };
-
-            return new RelayCommand(execute);
-        }
-
-        public static RelayCommand CreateHistoryCommand(MenuViewModel vm, IGameRepository repository)
-        {
-            var execute = (object o) =>
-            {
-                if ((string)o == "True")
-                {
-                    vm.GameResults = repository.GetResults(vm.UserId);
-                }
-                vm.IsHistory = !vm.IsHistory;
-            };
-
-            return new RelayCommand(execute);
-        }
-
-        public static RelayCommand CreateExitAccountCommand(MenuViewModel vm)
-        {
-            var execute = (object o) =>
-            {
-                vm.InitializeProp(true);
-            };
-
-            return new RelayCommand(execute);
-        }
-
-        public static RelayCommand CreateExitCommand(MenuViewModel vm)
-        {
-            var execute = (object o) =>
-            {
-                vm.InvokeExitRequest();
-            };
-
-            return new RelayCommand(execute);
-        }
-    }
+		private static void HandleAuth(MenuViewModel vm, Func<string, string, int> authFunc, string errorOnFail)
+		{
+			if (!string.IsNullOrWhiteSpace(vm.Login) && !string.IsNullOrWhiteSpace(vm.Password))
+			{
+				int result = authFunc(vm.Login, vm.Password);
+				if (result > 0)
+				{
+					vm.UserId = result;
+					vm.IsLoginScreen = false;
+				}
+				else
+				{
+					vm.Error = errorOnFail;
+				}
+			}
+			else
+			{
+				vm.Error = "Заповніть всі поля!";
+			}
+		}
+	}
 }


### PR DESCRIPTION
  There are several complex and bloated code sections in the class [GameCommandService](https://github.com/VadimSush/Minesweeper/blob/master/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs), particularly within the command-creation methods and the inner class CellActionService. I suggest replacing these code blocks with extracted methods to improve modularity, readability, and maintainability. This way, the class [GameCommandService](https://github.com/merelythesame/Minesweeper/blob/master/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs) delegates the functionality of command creation and validation to newly extracted helper methods such as [CreateCommand, BonusCommand, HandleAuth](https://github.com/merelythesame/Minesweeper/blob/master/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs#L197-L224).

- In CellActionService.ToggleFlagAt, flag/unflag logic was nested inside conditional statements. These were extracted into clearly named private methods [FlagCell](https://github.com/merelythesame/Minesweeper/blob/master/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs#L70-L75) and [UnflagCell](https://github.com/merelythesame/Minesweeper/blob/master/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs#L63-L68). This improves readability and helps to isolate side-effects in flag state management.
- The various CreateXCommand methods contained redundant patterns involving RelayCommand instantiation. These patterns were abstracted into the [CreateCommand](https://github.com/merelythesame/Minesweeper/blob/master/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs#L197-L198) method. For bonus-based commands (like showing bombs or safe cells), we introduced the [BonusCommand](https://github.com/merelythesame/Minesweeper/blob/master/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs#L200-L201) method to encapsulate common execution and validation patterns, reducing duplication.
- The CreateRegisterCommand and CreateLoginCommand shared complex login/password validation and error handling logic. This logic was centralized in the [HandleAuth](https://github.com/merelythesame/Minesweeper/blob/master/Minesweeper/Models/ViewModels/Commands/GameCommandService.cs#L203-L222) method, which takes the MenuViewModel, a repository method delegate, and a custom error message. This improves clarity and simplifies unit testing.

These changes help simplify command declarations, make logic intentions clearer, and isolate individual responsibilities—following principles of clean code and the Single Responsibility Principle.